### PR TITLE
Fix broken image link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 [Programmer's Notepad](http://www.pnotepad.org/) is a text editor for Windows.
 
-
-![Dark Theme](http://www.pnotepad.org/wp-content/uploads/2008/03/darktheme.png)
+![Screenshot](http://www.pnotepad.org/images/home1.png)
 
 It is primarily written in C++ and extensible using Python, and is built on the following technologies:
   - [Scintilla](https://www.scintilla.org/)


### PR DESCRIPTION
It looks like the README.md was referring to wordpress content (in folder wp-content), but that content is no longer present on the pnotepad.org site (presumably, since it moved to github pages). I've suggested a change of url for the screenshot.